### PR TITLE
Allow @mui/material v8 and v9 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "@mui/material": "^7.0.1",
+    "@mui/material": "^7.0.1 || ^8.0.0 || ^9.0.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },


### PR DESCRIPTION
## Summary
Broadens the `@mui/material` peer dependency from `^7.0.1` to `^7.0.1 || ^8.0.0 || ^9.0.0` so the package can be installed alongside MUI v8 and v9 without peer-dependency warnings/errors.

The package only uses MUI's `SvgIcon`, which has remained API-compatible across these major versions, so no code changes are required.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)